### PR TITLE
Fix mdbook-epub command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ## 电子书
 
-- 可使用 mdbook-epub 工具自行编译：`mdbook-epub --standalone true` 然后 epub 在 book 目录下
+- 可使用 mdbook-epub 工具自行编译：`mdbook-epub --standalone` 然后 epub 在 book 目录下
 - 扫码订阅《方法论》更新频道后下载: [进入](https://subdeer.cn/channel/landing/11)
 
 ## 在线阅读


### PR DESCRIPTION
Passing `true` to `--standalone` will cause `true` be used as a path hence the build will fail

mdbook-epub version 0.4.40

``` shell
 $ mdbook-epub --standalone true                                   
Running mdbook-epub as standalone app...
thread 'main' panicked at ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mdbook-epub-0.4.40/src/bin/mdbook-epub.rs:42:43:
book.toml root file is not found by a path "true": Couldn't open SUMMARY.md in "true/src" directory

Caused by:
    No such file or directory (os error 2)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
$ mdbook-epub --standalone          
Running mdbook-epub as standalone app...
$
```