### PR TITLE
Fix mdbook-epub cover image path

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -6,4 +6,4 @@ src = "src"
 title = "一人企业方法论"
 
 [output.epub]
-cover-image = "src/images/opb-book-cover-2.1.jpg"
+cover-image = "images/opb-book-cover-2.1.jpg"


### PR DESCRIPTION
Summary:
- Updates the epub cover image path to be relative to the mdBook source directory.
- This avoids mdbook-epub looking for `src/src/images/...`.

Closes #2

Testing:
- Verified the cover image exists at `src/images/opb-book-cover-2.1.jpg`.
- `mdbook-epub` is not installed in this environment, so I could not run the full epub build locally.

AI assistance: This configuration fix was prepared with AI assistance and reviewed before submission.